### PR TITLE
Add update image flag

### DIFF
--- a/bin/dockit
+++ b/bin/dockit
@@ -13,13 +13,14 @@ help() {
     printf -- '-i            skip ignores; do not remove files ignored by VCS or Docker\n'
     printf -- '-m <user>     mount directory as <user> instead of default\n'
     printf -- '-r <user>     run shell as <user> instead of default\n'
-    printf -- '-o <options>  pass <options> to docker run'
+    printf -- '-o <options>  pass <options> to docker run\n'
+    printf -- '-u            update image before mounting'
 
     exit 0
 
 }
 
-while getopts ":hdnim:r:o:" opt
+while getopts ":hdnim:r:o:u" opt
 do
     case $opt in
         h)
@@ -43,6 +44,9 @@ do
         o)
             dockopts=$OPTARG
             ;;
+        u)
+            update_image=1
+            ;;
         \?)
             printf 'Unrecognized option: -%s\n' "$OPTARG" 1>&2
             exit 1
@@ -61,7 +65,10 @@ then
 fi
 
 img=$1
-docker pull "$img" 1>&2
+if [ ! -z "$update_image" ]
+then
+    docker pull "$img" 1>&2
+fi
 
 user=$(docker image inspect "$img" --format "{{.ContainerConfig.User}}")
 


### PR DESCRIPTION
Sometimes I will be jumping in and out of containers a lot and waiting for `dockit` to try to pull the image each time gets tedious. 
This flag allows you to update the image using the `-u` flag but defaults to just loading the container. If it can't locally find the image, docker will download it anyways.
```bash
$ dockit -u debian
```

```
$ dockit -h
...
-u            update image before mounting
```