### PR TITLE
Add completion for bash & zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The included installer script will install `dockit` to `/usr/local`. If that
 doesn’t meet your needs, you can also run it directly from the cloned copy as
 `bin/dockit`.
 
+### Completion
+Completion scripts are included for `bash` and `zsh`.  
+See `install.sh` for more information
+
 ## Usage
 
 ```text

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+set -e
+
+bash_complete_dir="/etc/bash_completion.d"
+zsh_complete_dir="/usr/share/zsh/vendor-completions"
 
 if [ ! $(id -u) -eq 0 ]
 then
@@ -9,5 +13,32 @@ fi
 
 dir=$(dirname "$0")
 
-cp $dir/bin/dockit /usr/local/bin/dockit
-cp -r $dir/lib/dockit /usr/local/lib
+cp --update --verbose             $dir/bin/dockit /usr/local/bin/dockit
+cp --update --verbose --recursive $dir/lib/dockit /usr/local/lib
+
+#   Ensure that docker is installed and you are part of the docker group.
+#   This command will add you to the docker group:
+#   $usermod -a -G docker myusername"
+if command -v bash   &> /dev/null \
+    && command -v docker &> /dev/null \
+    && id -nG "$(whoami)" | grep -qw "docker"
+then
+    mkdir -p "$bash_complete_dir"
+    cp --update --verbose misc/dockit.bashcompletion "$bash_complete_dir"/dockit
+    echo "bash completion script installed"
+else
+    echo "bash completion script not installed"
+fi
+
+if command -v zsh    &> /dev/null \
+    && command -v docker &> /dev/null \
+    && id -nG "$(whoami)" | grep -qw "docker"
+then
+    mkdir -p "$zsh_complete_dir"
+    cp --update --verbose misc/dockit.zshcompletion "$zsh_complete_dir"/_dockit
+    echo "zsh completion script installed"
+    echo -e "\nYou may need to include this line in your ~/.zshrc file\n"
+    echo -e "    autoload bashcompinit && bashcompinit\n"
+else
+    echo "zsh completion script not installed"
+fi

--- a/misc/dockit.bashcompletion
+++ b/misc/dockit.bashcompletion
@@ -1,0 +1,9 @@
+# dockit(1) completion                                       -*- shell-script -*-
+_dockit()
+{
+	local images
+	images="$( docker images --format '{{.Repository}}:{{.Tag}}' )"
+	COMPREPLY=( $( compgen -W "$images" -- "$cur" ) )
+	__ltrim_colon_completions "$cur"
+}
+complete -F _dockit dockit

--- a/misc/dockit.zshcompletion
+++ b/misc/dockit.zshcompletion
@@ -1,0 +1,3 @@
+#compdef dockit
+
+complete -C "docker images --format '{{.Repository}}:{{.Tag}}'" dockit


### PR DESCRIPTION
Created to address #5 

**I changed the install shell** to bash to be able to do if checks with multiple comparisons. I'm not sure this is possible in sh

For a completion script to be installed, a few conditions need to be met:
* The shell should be installed
* docker installed and the user part of the docker group

Additional message for zsh users to include `bashcompinit`

zsh version has autocompletion, bash will simply list all existing images.

The bash completions script is added to `/etc/bash_completion.d/dockit`
zsh is added to `/usr/share/zsh/vendor-completions/_dockit`

___
I've tested both in the ubuntu image and they seem to be working well.
Bash needs `bash-completion` installed and zsh needs `bashcompinit` in `~/.zshrc`.
Make sure if testing to switch to a non-root user.